### PR TITLE
Fix issue #1

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,8 +2,8 @@
 
 <plugin>
     <class>org.jivesoftware.openfire.plugin.HazelcastPlugin</class>
-    <name>Hazelcast plugin</name>
-    <description>Adds clustering support</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Tom Evans</author>
     <version>${project.version}</version>
     <date>tbc</date>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,15 @@
     <name>Hazelcast Plugin</name>
     <description>Adds clustering support</description>
 
+    <repositories>
+        <!-- Where we obtain dependencies. -->
+        <repository>
+            <id>igniterealtime</id>
+            <name>Ignite Realtime Repository</name>
+            <url>https://igniterealtime.org/archiva/repository/maven/</url>
+        </repository>
+    </repositories>
+
     <developers>
         <developer>
             <name>Tom Evans</name>

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterListener.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterListener.java
@@ -146,7 +146,6 @@ public class ClusterListener implements MembershipListener, LifecycleListener {
 
         directedPresencesCache = CacheFactory.createCache(PresenceUpdateHandler.PRESENCE_CACHE_NAME);
 
-        joinCluster();
     }
 
     private void addEntryListener(Cache<?, ?> cache, EntryListener listener) {
@@ -230,7 +229,7 @@ public class ClusterListener implements MembershipListener, LifecycleListener {
         return allLists;
     }
 
-    public boolean isDone() {
+    private boolean isDone() {
         return done;
     }
 
@@ -599,7 +598,7 @@ public class ClusterListener implements MembershipListener, LifecycleListener {
         }
     }
 
-    private synchronized void joinCluster() {
+    synchronized void joinCluster() {
         if (!isDone()) { // already joined
             return;
         }
@@ -721,6 +720,7 @@ public class ClusterListener implements MembershipListener, LifecycleListener {
         clusterNodesInfo.remove(event.getMember().getUuid()); 
     }
     
+    @SuppressWarnings("WeakerAccess")
     public List<ClusterNodeInfo> getClusterNodesInfo() {
         return new ArrayList<>(clusterNodesInfo.values());
     }

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
@@ -148,6 +148,7 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
                 XMPPServer.getInstance().setNodeID(NodeID.getInstance(getClusterMemberID()));
                 // CacheFactory is now using clustered caches. We can add our listeners.
                 clusterListener = new ClusterListener(cluster);
+                clusterListener.joinCluster();
                 lifecycleListener = hazelcast.getLifecycleService().addLifecycleListener(clusterListener);
                 membershipListener = cluster.addMembershipListener(clusterListener);
                 logger.info("Hazelcast clustering started");
@@ -281,7 +282,7 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
 
     @Override
     public List<ClusterNodeInfo> getClusterNodesInfo() {
-        return clusterListener == null ? Collections.<ClusterNodeInfo>emptyList() : clusterListener.getClusterNodesInfo();
+        return clusterListener == null ? Collections.emptyList() : clusterListener.getClusterNodesInfo();
     }
 
     @Override


### PR DESCRIPTION
The ClusteredCacheFactory.isSeniorClusterMember() was returning false
because the clusterListener was null. The clusterListener was null
because the joinedCluster() event was being fired in the constructor of
the ClusterListener.

This fix moves the code that joins the cluster (and fires the event)
outside of the constructor, and calls it explicitly after the clusterListener
has been assigned.