### PR TITLE
Fix issue #3

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -7,6 +7,6 @@
     <author>Tom Evans</author>
     <version>${project.version}</version>
     <date>tbc</date>
-    <minServerVersion>4.3.0</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-beta</version>
+        <version>4.3.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>hazelcast</artifactId>
@@ -18,11 +18,24 @@
         </developer>
     </developers>
 
+    <repositories>
+        <!-- Where we obtain dependencies. -->
+        <repository>
+            <id>igniterealtime</id>
+            <name>Ignite Realtime Repository</name>
+            <url>https://igniterealtime.org/archiva/repository/maven/</url>
+        </repository>
+    </repositories>
+
     <build>
         <sourceDirectory>src/java</sourceDirectory>
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-jspc-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/i18n/hazelcast_i18n.properties
+++ b/src/i18n/hazelcast_i18n.properties
@@ -1,9 +1,0 @@
-##
-## Hazelcast Clustering Resource Bundle
-##
-## REVISION HISTORY
-##
-## 1.0.0
-##      Initial Release
-plugin.name=Hazelcast Clustering Plugin
-plugin.description=Clustering support for Openfire, powered by Hazelcast.

--- a/src/java/org/apache/jasper/runtime/JspSourceImports.java
+++ b/src/java/org/apache/jasper/runtime/JspSourceImports.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jasper.runtime;
+
+import java.util.Set;
+
+/**
+ * The EL engine needs access to the imports used in the JSP page to configure
+ * the ELContext. The imports are available at compile time but the ELContext
+ * is created lazily per page. This interface exposes the imports at runtime so
+ * that they may be added to the ELContext when it is created.
+ */
+public interface JspSourceImports {
+    Set<String> getPackageImports();
+    Set<String> getClassImports();
+}

--- a/src/java/org/jivesoftware/openfire/plugin/util/cluster/NodeRuntimeStats.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cluster/NodeRuntimeStats.java
@@ -23,7 +23,6 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.ResourceBundle;
 
 import org.jivesoftware.openfire.cluster.NodeID;
 import org.jivesoftware.util.cache.CacheFactory;
@@ -34,13 +33,6 @@ import org.jivesoftware.util.cache.ExternalizableUtil;
  * A utility class which helps to gather Hazelcast stats and information.
  */
 public class NodeRuntimeStats {
-
-    // This properties file is located in the Hazelcast JAR
-    private static final ResourceBundle config = ResourceBundle.getBundle("hazelcast-runtime");
-    
-    public static String getProviderConfig(String key) {
-        return config.getString(key);
-    }
 
     /**
      * Returns a Map of HazelcastRuntimeStats.NodeInfo objects keyed by cluster Member objects.

--- a/src/web/WEB-INF/web.xml
+++ b/src/web/WEB-INF/web.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+</web-app>

--- a/src/web/system-clustering-node.jsp
+++ b/src/web/system-clustering-node.jsp
@@ -2,10 +2,6 @@
 <%@ page import="org.jivesoftware.openfire.plugin.util.cluster.NodeRuntimeStats,
                  org.jivesoftware.util.cache.CacheFactory,
                  com.hazelcast.core.Hazelcast,
-                 com.hazelcast.core.Cluster,
-                 com.hazelcast.core.Member,
-                 com.hazelcast.config.ClasspathXmlConfig,
-                 com.hazelcast.config.Config,
                  org.jivesoftware.openfire.cluster.ClusterManager,
                  org.jivesoftware.openfire.cluster.NodeID,
                  org.jivesoftware.openfire.cluster.ClusterNodeInfo"
@@ -19,14 +15,9 @@
 <%@ page import="java.text.DecimalFormat" %>
 <%@ page import="java.text.NumberFormat" %>
 <%@ page import="java.util.*" %>
-<%@ page import="java.util.LinkedList" %>
 
 <jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager"  />
 <% webManager.init(request, response, session, application, out ); %>
-
-
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <html>
 <head>
@@ -382,26 +373,6 @@ Cache statistics for this cluster node appear below.
 </div>
 
 <br /><br />
-
-<div class="jive-table">
-<table cellpadding="0" cellspacing="0" border="0" width="100%">
-<thead>
-    <tr>
-        <th colspan="2">
-            Openfire Cluster Details
-        </th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td width="100%">
-            Hazelcast Version <%= NodeRuntimeStats.getProviderConfig("hazelcast.version") %> 
-            Build <%= NodeRuntimeStats.getProviderConfig("hazelcast.build") %>
-        </td>
-    </tr>
-</tbody>
-</table>
-</div>
 
 <br/>
 


### PR DESCRIPTION
a) The JSP was not being correctly compiled due to isses in pom.xml
b) The JSP made references to information that is no longer available
c) Added a JspSourceImports.java file - this is a copy of the one found
in apache-jsp-8.5.24.2, missing from earlier versions of Openfire. This
allows the plugin to work on earlier Openfire versions.