### PR TITLE
Fix issue #19 - only change the NodeID if absolutely necessary.

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -49,6 +49,7 @@ Hazelcast Clustering Plugin Changelog
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/13'>Issue #13</a>] - Less dramatic log messages when running a one-node cluster</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/16'>Issue #16</a>] - Expose host name of cluster members on the admin UI</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/19'>Issue #19</a>] - Stop changing the XMPPServer NodeID</li>
 </ul>
 <p><b>2.4.0</b> -- January 25, 2019</p>
 

--- a/src/java/org/jivesoftware/openfire/plugin/HazelcastPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/HazelcastPlugin.java
@@ -18,12 +18,15 @@ package org.jivesoftware.openfire.plugin;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.UUID;
 
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.cluster.ClusterManager;
+import org.jivesoftware.openfire.cluster.NodeID;
 import org.jivesoftware.openfire.container.Plugin;
 import org.jivesoftware.openfire.container.PluginManager;
 import org.jivesoftware.openfire.container.PluginManagerListener;
@@ -45,6 +48,14 @@ public class HazelcastPlugin implements Plugin {
 
     @Override
     public void initializePlugin(final PluginManager manager, final File pluginDirectory) {
+
+        if (XMPPServer.getInstance().getNodeID().equals(new byte[0])) {
+            // TODO: (Greg 2019-03-14) Remove this when minServerVersion is 4.4.0 - that version does not require the node ID to be set
+            final NodeID nodeID = NodeID.getInstance(UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
+            LOGGER.info("Setting the XMPPServer node id once and for all to {}", nodeID);
+            XMPPServer.getInstance().setNodeID(nodeID);
+        }
+
         LOGGER.info("Waiting for other plugins to initialize before initializing clustering");
         manager.addPluginManagerListener(new PluginManagerListener() {
             @Override

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
@@ -20,7 +20,6 @@ import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -60,6 +59,7 @@ import com.hazelcast.config.ClasspathXmlConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.config.MemberAttributeConfig;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
@@ -132,7 +132,9 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
         do {
             try {
                 final Config config = new ClasspathXmlConfig(HAZELCAST_CONFIG_FILE);
-                config.getMemberAttributeConfig().setStringAttribute(HazelcastClusterNodeInfo.HOST_NAME_ATTRIBUTE, XMPPServer.getInstance().getServerInfo().getHostname());
+                final MemberAttributeConfig memberAttributeConfig = config.getMemberAttributeConfig();
+                memberAttributeConfig.setStringAttribute(HazelcastClusterNodeInfo.HOST_NAME_ATTRIBUTE, XMPPServer.getInstance().getServerInfo().getHostname());
+                memberAttributeConfig.setStringAttribute(HazelcastClusterNodeInfo.NODE_ID_ATTRIBUTE, XMPPServer.getInstance().getNodeID().toString());
                 config.setInstanceName("openfire");
                 config.setClassLoader(loader);
                 if (JMXManager.isEnabled() && HAZELCAST_JMX_ENABLED) {
@@ -141,12 +143,7 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
                 }
                 hazelcast = Hazelcast.newHazelcastInstance(config);
                 cluster = hazelcast.getCluster();
-
-                // Update the running state of the cluster
-                state = cluster != null ? State.started : State.stopped;
-
-                // Set the ID of this cluster node
-                XMPPServer.getInstance().setNodeID(NodeID.getInstance(getClusterMemberID()));
+                state = State.started;
                 // CacheFactory is now using clustered caches. We can add our listeners.
                 clusterListener = new ClusterListener(cluster);
                 clusterListener.joinCluster();
@@ -227,7 +224,6 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
         lifecycleListener = null;
         membershipListener = null;
         clusterListener = null;
-        XMPPServer.getInstance().setNodeID(null);
 
         // Reset packet router to use to deliver packets to remote cluster nodes
         XMPPServer.getInstance().getRoutingTable().setRemotePacketRouter(null);
@@ -299,7 +295,7 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
     public byte[] getSeniorClusterMemberID() {
         if (cluster != null && !cluster.getMembers().isEmpty()) {
             final Member oldest = cluster.getMembers().iterator().next();
-            return oldest.getUuid().getBytes(StandardCharsets.UTF_8);
+            return getNodeID(oldest).toByteArray();
         } else {
             return null;
         }
@@ -308,7 +304,7 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
     @Override
     public byte[] getClusterMemberID() {
         if (cluster != null) {
-            return cluster.getLocalMember().getUuid().getBytes(StandardCharsets.UTF_8);
+            return getNodeID(cluster.getLocalMember()).toByteArray();
         } else {
             return null;
         }
@@ -410,7 +406,7 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
                 logger.error("Failed to execute cluster task", e);
             }
         } else {
-            logger.warn("No cluster members selected for cluster task " + task.getClass().getName());
+            logger.debug("No cluster members selected for cluster task " + task.getClass().getName());
         }
         return result;
     }
@@ -462,14 +458,13 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
     }
 
     private Member getMember(final byte[] nodeID) {
-        Member result = null;
+        final NodeID memberToFind = NodeID.getInstance(nodeID);
         for (final Member member : cluster.getMembers()) {
-            if (Arrays.equals(member.getUuid().getBytes(StandardCharsets.UTF_8), nodeID)) {
-                result = member;
-                break;
+            if (memberToFind.equals(getNodeID(member))) {
+                return member;
             }
         }
-        return result;
+        return null;
     }
 
     @Override
@@ -479,7 +474,7 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
             if (cacheStats == null) {
                 cacheStats = hazelcast.getMap("opt-$cacheStats");
             }
-            final String uid = cluster.getLocalMember().getUuid();
+            final String uid = getNodeID(cluster.getLocalMember()).toString();
             final Map<String, long[]> stats = new HashMap<>();
             for (final String cacheName : caches.keySet()) {
                 final Cache cache = caches.get(cacheName);
@@ -577,6 +572,11 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
         starting,
         started
     }
+
+    public static NodeID getNodeID(final Member member) {
+        return NodeID.getInstance(member.getStringAttribute(HazelcastClusterNodeInfo.NODE_ID_ATTRIBUTE).getBytes(StandardCharsets.UTF_8));
+    }
+
 }
 
 

--- a/src/java/org/jivesoftware/openfire/plugin/util/cluster/HazelcastClusterNodeInfo.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cluster/HazelcastClusterNodeInfo.java
@@ -16,11 +16,10 @@
 
 package org.jivesoftware.openfire.plugin.util.cluster;
 
-import java.nio.charset.StandardCharsets;
-
 import org.jivesoftware.openfire.cluster.ClusterManager;
 import org.jivesoftware.openfire.cluster.ClusterNodeInfo;
 import org.jivesoftware.openfire.cluster.NodeID;
+import org.jivesoftware.openfire.plugin.util.cache.ClusteredCacheFactory;
 
 import com.hazelcast.core.Member;
 
@@ -33,17 +32,17 @@ import com.hazelcast.core.Member;
 public class HazelcastClusterNodeInfo implements ClusterNodeInfo {
 
     public static final String HOST_NAME_ATTRIBUTE = "hostname";
+    public static final String NODE_ID_ATTRIBUTE = "node-id";
     private final String hostname;
     private final NodeID nodeID;
     private final long joinedTime;
     private final boolean seniorMember;
 
     public HazelcastClusterNodeInfo(final Member member, final long joinedTime) {
-        final byte[] memberBytes = member.getUuid().getBytes(StandardCharsets.UTF_8);
         this.hostname = member.getStringAttribute(HOST_NAME_ATTRIBUTE) + " (" + member.getSocketAddress().getHostString() + ")";
-        this.nodeID = NodeID.getInstance(memberBytes);
+        this.nodeID = ClusteredCacheFactory.getNodeID(member);
         this.joinedTime = joinedTime;
-        this.seniorMember = ClusterManager.getSeniorClusterMember().equals(memberBytes);
+        this.seniorMember = ClusterManager.getSeniorClusterMember().equals(nodeID);
     }
 
     public String getHostName() {


### PR DESCRIPTION
Note 1; this PR will change the NodeID - but only once, and only immediately the plugin is loaded, and only if the Openfire it is installed on still has the `new byte [0]` configured. This is to maintain backward compatibility with older versions of Openfire, which do not set the NodeID on startup.

Note 2; implementing this turned up a few long-standing bugs. Specifically, there were a number of cases where a NodeID was compared to a byte[] - e.g. https://github.com/igniterealtime/openfire-hazelcast-plugin/blob/6f3e13591a5ec78b4f18476e2e27bb397a702363/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterListener.java#L418-L420