### PR TITLE
log task result on trace level to reduce overhead on debug level

### DIFF
--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
@@ -423,7 +423,7 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
             try {
                 final Future<T> future = hazelcast.getExecutorService(HAZELCAST_EXECUTOR_SERVICE_NAME).submitToMember(new CallableTask<>(task), member);
                 result = future.get(MAX_CLUSTER_EXECUTION_TIME, TimeUnit.SECONDS);
-                logger.debug("DistributedTask result: " + (result == null ? "null" : result));
+                logger.trace("DistributedTask result: " + (result == null ? "null" : result));
             } catch (final TimeoutException te) {
                 logger.error("Failed to execute cluster task within " + MAX_CLUSTER_EXECUTION_TIME + " seconds", te);
             } catch (final Exception e) {
@@ -555,7 +555,8 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
         @Override
         public V call() {
             task.run();
-            logger.debug("CallableTask[" + task.getClass().getName() + "] result: " + task.getResult());
+            if (logger.isTraceEnabled())
+                logger.trace("CallableTask[{}] result: {}", task.getClass().getName(), task.getResult());
             return task.getResult();
         }
     }

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
@@ -423,7 +423,7 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
             try {
                 final Future<T> future = hazelcast.getExecutorService(HAZELCAST_EXECUTOR_SERVICE_NAME).submitToMember(new CallableTask<>(task), member);
                 result = future.get(MAX_CLUSTER_EXECUTION_TIME, TimeUnit.SECONDS);
-                logger.trace("DistributedTask result: " + (result == null ? "null" : result));
+                logger.trace("DistributedTask result: {}", result);
             } catch (final TimeoutException te) {
                 logger.error("Failed to execute cluster task within " + MAX_CLUSTER_EXECUTION_TIME + " seconds", te);
             } catch (final Exception e) {
@@ -555,8 +555,7 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
         @Override
         public V call() {
             task.run();
-            if (logger.isTraceEnabled())
-                logger.trace("CallableTask[{}] result: {}", task.getClass().getName(), task.getResult());
+            logger.trace("CallableTask[{}] result: {}", task.getClass().getName(), task.getResult());
             return task.getResult();
         }
     }


### PR DESCRIPTION
This pull request reduces the logging overhead on debug level. It sets the output of task results to trace. Log the complete result on debug level might not be usefull, because there are a lots of running task with potential much data. This can be more of a hindrance than helpful in debugging.