### PR TITLE
change the computation of the max cache size

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -7,6 +7,6 @@
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
     <date>04/26/2019</date>
-    <minServerVersion>4.0.0</minServerVersion>
+    <minServerVersion>4.5.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,6 +7,6 @@
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
     <date>04/26/2019</date>
-    <minServerVersion>4.5.0</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>hazelcast</artifactId>

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCache.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCache.java
@@ -148,9 +148,9 @@ public class ClusteredCache<K extends Serializable, V extends Serializable> impl
     }
 
     @Override
-    public int getCacheSize() {
+    public long getCacheSize() {
         final LocalMapStats stats = map.getLocalMapStats();
-        return (int) (stats.getOwnedEntryMemoryCost() + stats.getBackupEntryMemoryCost());
+        return stats.getOwnedEntryMemoryCost() + stats.getBackupEntryMemoryCost();
     }
 
     @Override
@@ -159,7 +159,7 @@ public class ClusteredCache<K extends Serializable, V extends Serializable> impl
     }
 
     @Override
-    public void setMaxCacheSize(final int maxSize) {
+    public void setMaxCacheSize(final long maxSize) {
         CacheFactory.setMaxSizeProperty(getName(), maxSize);
     }
 

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCache.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCache.java
@@ -38,7 +38,7 @@ import com.hazelcast.monitor.LocalMapStats;
 public class ClusteredCache<K extends Serializable, V extends Serializable> implements Cache<K, V> {
 
     private static final Logger logger = LoggerFactory.getLogger(ClusteredCache.class);
-    
+
     private final Set<String> listeners = ConcurrentHashMap.newKeySet();
 
     /**
@@ -148,7 +148,12 @@ public class ClusteredCache<K extends Serializable, V extends Serializable> impl
     }
 
     @Override
-    public long getCacheSize() {
+    public int getCacheSize() {
+        return (int) getLongCacheSize();
+    }
+
+    @Override
+    public long getLongCacheSize() {
         final LocalMapStats stats = map.getLocalMapStats();
         return stats.getOwnedEntryMemoryCost() + stats.getBackupEntryMemoryCost();
     }
@@ -156,6 +161,11 @@ public class ClusteredCache<K extends Serializable, V extends Serializable> impl
     @Override
     public long getMaxCacheSize() {
         return CacheFactory.getMaxCacheSize(getName());
+    }
+
+    @Override
+    public void setMaxCacheSize(int i) {
+        setMaxCacheSize((long) i);
     }
 
     @Override

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
@@ -475,7 +475,12 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
                 // current size, max size, num elements, cache
                 // hits, cache misses.
                 final long[] info = new long[5];
-                info[0] = cache.getCacheSize();
+                if(cache instanceof ClusteredCache) {
+                    info[0] = ((ClusteredCache)cache).getLongCacheSize();
+                } else {
+                    // Cache.getLongCacheSize was introduced in OF 4.5, so use the old API for comparability for now
+                    info[0] = cache.getCacheSize();
+                }
                 info[1] = cache.getMaxCacheSize();
                 info[2] = cache.size();
                 info[3] = cache.getCacheHits();


### PR DESCRIPTION
Before this the number of bytes which are configured in openfire are set es megabyte.
Also change the API to make it able to set the max cache size value as long.

(See https://discourse.igniterealtime.org/t/bug-in-cache-konfiguration/86452/)
(Depends on: https://github.com/igniterealtime/Openfire/pull/1506)