### PR TITLE
fix for #69: improve split-brain by letting 'leave' play out before joining again.

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -50,6 +50,7 @@ Hazelcast Clustering Plugin Changelog
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/50'>Issue #50</a>] - Move non-Hazelcast code to Openfire-core</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/65'>Issue #65</a>] - Postpone member joined event until joining node is ready to receive new data</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/69'>Issue #69</a>] - When recovering split-brain, let 'leave' play out before 'joining' again</li>
 </ul>
 
 <p><b>2.5.1</b> -- September 29, 2021.</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>${project.description}</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>09/29/2021</date>
+    <date>10/26/2021</date>
     <minServerVersion>4.7.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
 </plugin>

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterListener.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterListener.java
@@ -165,8 +165,18 @@ public class ClusterListener implements MembershipListener, LifecycleListener {
                 logger.warn("Recovering from split-brain; firing leftCluster()/joinedCluster() events");
                 ClusteredCacheFactory.fireLeftClusterAndWaitToComplete(Duration.ofSeconds(30));
                 logger.debug("Firing joinedCluster() event");
-                ClusterManager.fireJoinedCluster(true);
+                ClusterManager.fireJoinedCluster(false);
 
+                try {
+                    logger.debug("Postponing notification of other nodes for 30 seconds. This allows all local leave/join processing to be finished and local cache backups to be stabilized before receiving events from other nodes.");
+                    Thread.sleep(30000L);
+                } catch (InterruptedException e) {
+                    logger.warn("30 Second wait was interrupted.", e);
+                }
+
+                // The following line was intended to wait until all local handling finishes before informing other
+                // nodes. However that proved to be insufficient. Hence the 30 second default wait in the lines above.
+                // TODO Instead of the 30 second wait, we should look (and then wait) for some trigger or event that signifies that local handling has completed and caches have stabilized.
                 waitForClusterCacheToBeInstalled();
 
                 // Let the other nodes know that we joined the cluster


### PR DESCRIPTION
These are the same changes as in https://github.com/igniterealtime/openfire-hazelcast-plugin/pull/68 but reorganized and with some metadata added. 