### PR TITLE
fixes #74: Log warnings when using plugin-provided classes in cluster…

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -52,6 +52,7 @@ Hazelcast Clustering Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/65'>Issue #65</a>] - Postpone member joined event until joining node is ready to receive new data</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/69'>Issue #69</a>] - When recovering split-brain, let 'leave' play out before 'joining' again</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/71'>Issue #71</a>] - Send member joined notification across the cluster on clustering start</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/74'>Issue #74</a>] - Warn against usage of plugin-provided classes in Hazelcast</li>
 </ul>
 
 <p><b>2.5.1</b> -- September 29, 2021.</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>${project.description}</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>10/26/2021</date>
+    <date>11/17/2021</date>
     <minServerVersion>4.7.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
 </plugin>


### PR DESCRIPTION
…ed caches/tasks

When an instance of a class that is loaded by a PluginClassLoader is used in a Cache or Task, reloading the plugin (and thus replacing the PluginClassLoader) can cause ClassCastExceptions.

This commit detects this usage, and logs warnings. A throttle has been applied to the amount of duplicate warnings logged, to prevent the logs from being flooded with the same message.