### PR TITLE
#76 Finish leftCluster handling before invoking joinCluster handlers

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -52,6 +52,7 @@ Hazelcast Clustering Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/65'>Issue #65</a>] - Postpone member joined event until joining node is ready to receive new data</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/69'>Issue #69</a>] - When recovering split-brain, let 'leave' play out before 'joining' again</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/71'>Issue #71</a>] - Send member joined notification across the cluster on clustering start</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/76'>Issue #76</a>] - Finish leftCluster handling before invoking joinCluster handlers</li>
 </ul>
 
 <p><b>2.5.1</b> -- September 29, 2021.</p>

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
@@ -630,7 +630,9 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
             }
         };
         try {
-            ClusterManager.addListener(clusterEventListener);
+            // Add a listener at the ultimate end of the list of all listeners, to detect that left-cluster event handling
+            // has been invoked for all before proceeding.
+            ClusterManager.addListener(clusterEventListener, Integer.MAX_VALUE);
             logger.debug("Firing leftCluster() event");
             ClusterManager.fireLeftCluster();
             logger.debug("Waiting for leftCluster() event to be called [timeout={}]", StringUtils.getFullElapsedTime(timeout));


### PR DESCRIPTION
The wait routine registers a temporary event listener for detecting that all leftCluster handling has been done. This new listener was added somewhere in the middle of the listener list, causing the wait routine to finish while not all handlers had been invoked.

This PR fixes that bug, and fixes #76.