### PR TITLE
Use plugin classloader when executing task defined in a plugin

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -50,6 +50,7 @@ Hazelcast Clustering Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/103'>Issue #103</a>] - Fix Cluster initialization race condition</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/102'>Issue #102</a>] - Remove unused code in ClusterListener</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/81'>Issue #81</a>] - ClusterExternalizableUtil should not ignore provided ClassLoader instances</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/79'>Issue #79</a>] - Use plugin classloader when executing task defined in a plugin</li>
 </ul>
 
 <p><b>3.0.0</b> -- September 12, 2024</p>


### PR DESCRIPTION
When a clustered tasks is executed (particularly when that task returns a value), class loading issues can occur when the task is defined in a plugin. The classes that are used by the task might not be accessible by the (context class loader of the) thread that executes the task.

When a task is executed that is defined in a plugin, the context class loader of the thread should be switched to the plugin class loader during the execution of the task to work around this issue.

Be aware of #74: Using Tasks defined in a plugin causes issues (particularly when reloading that plugin). That problem remains, even with the improvement suggested here.

fixes #79