### PR TITLE
fixes #86: Reduce overhead of loading class definitions

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,12 @@
 Hazelcast Clustering Plugin Changelog
 </h1>
 
+<p><b>2.6.1</b> -- (tbd)</p>
+
+<ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/86'>Issue #86</a>] - Reduce overhead of loading class definitions</li>
+</ul>
+
 <p><b>2.6.0</b> -- December 6, 2021</p>
 <strong>NOTE: This version of the plugin requires Openfire 4.7.0 or higher</strong>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>${project.description}</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>12/06/2021</date>
+    <date>2022-10-19</date>
     <minServerVersion>4.7.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,12 @@
             <artifactId>hazelcast</artifactId>
             <version>3.12.5</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterClassLoader.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterClassLoader.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ClusterClassLoader extends ClassLoader {
 
-    private static Logger logger = LoggerFactory.getLogger(ClusterClassLoader.class);
+    private static final Logger logger = LoggerFactory.getLogger(ClusterClassLoader.class);
 
     private static final SystemProperty<String> HAZELCAST_CONFIG_DIR = SystemProperty.Builder.ofType(String.class)
         .setKey("hazelcast.config.xml.directory")

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterExternalizableUtil.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterExternalizableUtil.java
@@ -53,9 +53,11 @@ public class ClusterExternalizableUtil implements ExternalizableUtilStrategy {
 
     private static final Cache<String, Class<?>> CLASS_CACHE = CacheFactory.createLocalCache("Cluster Class Definitions");
 
-    static {
-        // TODO: This value is kept low to account for classes removed when a plugin gets unloaded. Replace this with a mechanism that detects plugin changes.
-        CLASS_CACHE.setMaxLifetime(5000);
+    /**
+     * Removes all class definitions from the cache that is used to speed up class loading.
+     */
+    public static void purgeCachedClassDefinitions() {
+        CLASS_CACHE.clear();
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterExternalizableUtil.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterExternalizableUtil.java
@@ -428,13 +428,10 @@ public class ClusterExternalizableUtil implements ExternalizableUtilStrategy {
             int len = in.readInt();
             byte[] buf = new byte[len];
             in.readFully(buf);
-            ObjectInputStream oin = newObjectInputStream(new ByteArrayInputStream(buf));
-            try {
+            try (ObjectInputStream oin = newObjectInputStream(new ByteArrayInputStream(buf))) {
                 return oin.readObject();
             } catch (ClassNotFoundException e) {
                 throw new IOException(e);
-            } finally {
-                oin.close();
             }
         } else {
             throw new IOException("Unknown object type=" + type);
@@ -459,9 +456,9 @@ public class ClusterExternalizableUtil implements ExternalizableUtilStrategy {
             throw new IllegalArgumentException("ClassName cannot be null!");
         }
         if (className.length() <= MAX_PRIM_CLASSNAME_LENGTH && Character.isLowerCase(className.charAt(0))) {
-            for (int i = 0; i < PRIMITIVE_CLASSES_ARRAY.length; i++) {
-                if (className.equals(PRIMITIVE_CLASSES_ARRAY[i].getName())) {
-                    return PRIMITIVE_CLASSES_ARRAY[i];
+            for (Class aClass : PRIMITIVE_CLASSES_ARRAY) {
+                if (className.equals(aClass.getName())) {
+                    return aClass;
                 }
             }
         }

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCache.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCache.java
@@ -26,7 +26,6 @@ import org.jivesoftware.openfire.cluster.ClusteredCacheEntryListener;
 import org.jivesoftware.openfire.cluster.NodeID;
 import org.jivesoftware.openfire.container.Plugin;
 import org.jivesoftware.openfire.container.PluginClassLoader;
-import org.jivesoftware.openfire.container.PluginManager;
 import org.jivesoftware.util.cache.Cache;
 import org.jivesoftware.util.cache.CacheFactory;
 import org.slf4j.Logger;

--- a/src/resources/hazelcastplugin_i18n.properties
+++ b/src/resources/hazelcastplugin_i18n.properties
@@ -1,3 +1,4 @@
+system_property.hazelcast.cache.class.duration=The maximum duration that a loaded class definition is cached.
 system_property.hazelcast.config.xml.directory=The folder containing any additional Hazelcast configuration files
 system_property.hazelcast.executor.service.name=The name of the Hazelcast executor used for running cluster wide tasks
 system_property.hazelcast.max.execution.seconds=The maximum amount of time to spend running cluster wide tasks

--- a/src/resources/hazelcastplugin_i18n.properties
+++ b/src/resources/hazelcastplugin_i18n.properties
@@ -1,4 +1,3 @@
-system_property.hazelcast.cache.class.duration=The maximum duration that a loaded class definition is cached.
 system_property.hazelcast.config.xml.directory=The folder containing any additional Hazelcast configuration files
 system_property.hazelcast.executor.service.name=The name of the Hazelcast executor used for running cluster wide tasks
 system_property.hazelcast.max.execution.seconds=The maximum amount of time to spend running cluster wide tasks

--- a/src/test/java/org/jivesoftware/openfire/plugin/util/cache/ClusterExternalizableUtilTest.java
+++ b/src/test/java/org/jivesoftware/openfire/plugin/util/cache/ClusterExternalizableUtilTest.java
@@ -17,7 +17,9 @@ package org.jivesoftware.openfire.plugin.util.cache;
 
 import com.google.common.primitives.Bytes;
 import org.dom4j.tree.DefaultElement;
+import org.jivesoftware.util.cache.CacheFactory;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
@@ -29,6 +31,11 @@ import java.util.List;
 
 public class ClusterExternalizableUtilTest
 {
+    @BeforeClass
+    public static void setup() throws Exception {
+        CacheFactory.initialize();
+    }
+
     /**
      * Verifies that ClusterExternalizableUtil.readObject() successfully deserializes a Collection of Messages.
      */

--- a/src/test/java/org/jivesoftware/openfire/plugin/util/cache/ClusterExternalizableUtilTest.java
+++ b/src/test/java/org/jivesoftware/openfire/plugin/util/cache/ClusterExternalizableUtilTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.plugin.util.cache;
+
+import com.google.common.primitives.Bytes;
+import org.dom4j.tree.DefaultElement;
+import org.junit.Assert;
+import org.junit.Test;
+import org.xmpp.packet.JID;
+import org.xmpp.packet.Message;
+
+import java.io.*;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+public class ClusterExternalizableUtilTest
+{
+    /**
+     * Verifies that ClusterExternalizableUtil.readObject() successfully deserializes a Collection of Messages.
+     */
+    @Test
+    public void testReadObjectWithCollection() throws Exception
+    {
+        // Setup test fixture.
+        final Message m1 = new Message();
+        m1.setBody("test one two three");
+        m1.setTo(new JID("foo", "example.org", "test"));
+        m1.setFrom(new JID("bar", "example.org", "barfoo"));
+        final Message m2 = new Message();
+        m2.setBody("The brown fox jumped over the ... something");
+        m2.setTo(new JID("john", "example.com", "aw23r2"));
+        m2.setFrom(new JID("jane", "example.net", "asdf"));
+
+        final List<DefaultElement> elements = new LinkedList<>();
+        elements.add((DefaultElement) m1.getElement());
+        elements.add((DefaultElement) m2.getElement());
+
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        final ObjectOutputStream oos = new ObjectOutputStream(bos);
+        oos.writeObject(elements);
+        oos.close();
+        final byte[] buf = bos.toByteArray();
+
+        final byte[] data = Bytes.concat(new byte[]{10}, intToByteArray(buf.length), buf);
+
+        // Execute system under test.
+        final DataInput in = new DataInputStream(new ByteArrayInputStream(data));
+        final Object o = ClusterExternalizableUtil.readObject(in);
+
+        // Verify results.
+        Assert.assertTrue(o instanceof LinkedList);
+        Assert.assertEquals(elements.size(), ((Collection) o).size());
+    }
+
+    /**
+     * Verifies that ClusterExternalizableUtil.readObject() successfully deserializes multiple instances.
+     * Collectively, the instances make up for a Collection of Messages equal to that used in {@link #testReadObjectWithCollection()}
+     */
+    @Test
+    public void testReadObjectWithMultipleInstances() throws Exception
+    {
+        // Setup test fixture.
+        final Message m1 = new Message();
+        m1.setBody("test one two three");
+        m1.setTo(new JID("foo", "example.org", "test"));
+        m1.setFrom(new JID("bar", "example.org", "barfoo"));
+        final Message m2 = new Message();
+        m2.setBody("The brown fox jumped over the ... something");
+        m2.setTo(new JID("john", "example.com", "aw23r2"));
+        m2.setFrom(new JID("jane", "example.net", "asdf"));
+
+        final List<DefaultElement> elements = new LinkedList<>();
+        elements.add((DefaultElement) m1.getElement());
+        elements.add((DefaultElement) m2.getElement());
+
+        final ByteArrayOutputStream bos1 = new ByteArrayOutputStream();
+        final ObjectOutputStream oos1 = new ObjectOutputStream(bos1);
+        oos1.writeObject(elements.get(0));
+        oos1.close();
+        final byte[] buf1 = bos1.toByteArray();
+
+        final ByteArrayOutputStream bos2 = new ByteArrayOutputStream();
+        final ObjectOutputStream oos2 = new ObjectOutputStream(bos2);
+        oos2.writeObject(elements.get(1));
+        oos2.close();
+        final byte[] buf2 = bos2.toByteArray();
+
+        final byte[] data = Bytes.concat(new byte[]{2}, intToByteArray(elements.size()), new byte[] {10}, intToByteArray(buf1.length), buf1, new byte[] {10}, intToByteArray(buf2.length), buf2);
+
+        // Execute system under test & verify results
+        final DataInput in = new DataInputStream(new ByteArrayInputStream(data));
+        Object o;
+        o = ClusterExternalizableUtil.readObject(in);
+        Assert.assertTrue(o instanceof Integer);
+        o = ClusterExternalizableUtil.readObject(in);
+        Assert.assertTrue(String.valueOf(o), o instanceof DefaultElement);
+        Assert.assertEquals(elements.get(0).asXML(), ((DefaultElement)o).asXML());
+        o = ClusterExternalizableUtil.readObject(in);
+        Assert.assertTrue(o instanceof DefaultElement);
+        Assert.assertEquals(elements.get(1).asXML(), ((DefaultElement)o).asXML());
+    }
+
+    private byte[] intToByteArray(final int i) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(bos);
+        dos.writeInt(i);
+        dos.flush();
+        return bos.toByteArray();
+    }
+}


### PR DESCRIPTION
This adds a simple cache that stores class definitions loaded by name. As these definitions are looked up for pretty much every serialization action in the cluster, these add significant overhead.

Classes could be loaded/unloaded dynamically. ~To account for that, the amount of time that class definitions survive in a cache should be limited.~

~This commit introduces two new properties:~
~- `hazelcast.cache.class.duration` - The maximum duration that a loaded class definition is cached.~
~- `hazelcast.cache.class.maxsize` - The maximum amount of cached class definitions (-1 for unlimited)~

Update: now listens to plugin changes