### PR TITLE
OF-2792: Improve cache usage reporting

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,12 @@
 Hazelcast Clustering Plugin Changelog
 </h1>
 
+<p><b>2.7.0</b> -- (tbd)</p>
+<strong>NOTE: This version of the plugin requires Openfire 4.8.1 or higher</strong>
+<ul>
+    <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-2792'>Issue OF-2792</a>] - Cache summary page shows wrong stats when using Clustering</li>
+</ul>
+
 <p><b>2.6.1</b> -- November 9, 2022</p>
 
 <ul>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>${project.description}</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2022-11-09</date>
-    <minServerVersion>4.7.0</minServerVersion>
+    <date>2024-02-08</date>
+    <minServerVersion>4.8.1</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.7.0-beta</version>
+        <version>4.8.1</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>hazelcast</artifactId>
-    <version>2.6.2-SNAPSHOT</version>
+    <version>2.7.0-SNAPSHOT</version>
     <name>Hazelcast Plugin</name>
     <description>Adds clustering support</description>
 


### PR DESCRIPTION
Clustered Caches should report their actual size, TTL and units used, instead of defaulting to the properties that define non-clustered caches.

See https://igniterealtime.atlassian.net/browse/OF-2792 for a detailed description of the problems addressed by this commit.

This commit assumes that the [corresponding Openfire fix for OF-2792](https://github.com/igniterealtime/Openfire/pull/2410) are merged into and released as Openfire 4.8.1.

This is a screenshot of the changes in this PR that are combined with the corresponding Openfire changes:

![image](https://github.com/igniterealtime/openfire-hazelcast-plugin/assets/4253898/d579e895-4c37-41d1-8e8b-e825b8a3eeeb)
