### PR TITLE
Fix compatibility with Openfire 4.9.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ Hazelcast Clustering Plugin Changelog
 <p><b>3.0.0</b> -- (tbd)</p>
 <strong>NOTE: This version of the plugin requires Openfire 4.8.1 or higher</strong>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/97'>Issue #97</a>] - Compatibility issue with Openfire 4.9.0</li>
     <li>[<a href='https://igniterealtime.atlassian.net/browse/OF-2792'>Issue OF-2792</a>] - Cache summary page shows wrong stats when using Clustering</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/59'>Upgrade to Hazelcast 5.3.7</a>] - Upgrade to Hazelcast 5.3.7</li>
 </ul>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>${project.description}</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2024-02-08</date>
+    <date>2024-09-06</date>
     <minServerVersion>4.8.1</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
 </plugin>

--- a/src/java/org/jivesoftware/openfire/plugin/HazelcastPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/HazelcastPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2022-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ public class HazelcastPlugin implements Plugin {
         LOGGER.info("All plugins have initialized; initializing clustering");
 
         try {
-            final Path pathToLocalHazelcastConfig = Paths.get(JiveGlobals.getHomeDirectory(), "conf/hazelcast-local-config.xml");
+            final Path pathToLocalHazelcastConfig = JiveGlobals.getHomePath().resolve("conf/hazelcast-local-config.xml");
             if (!Files.exists(pathToLocalHazelcastConfig)) {
                 Files.copy(Paths.get(hazelcastPluginDirectory.getAbsolutePath(), "classes/hazelcast-local-config.template.xml"), pathToLocalHazelcastConfig);
             }

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterClassLoader.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ public class ClusterClassLoader extends ClassLoader {
 
     private static final SystemProperty<String> HAZELCAST_CONFIG_DIR = SystemProperty.Builder.ofType(String.class)
         .setKey("hazelcast.config.xml.directory")
-        .setDefaultValue(JiveGlobals.getHomeDirectory() + "/conf")
+        .setDefaultValue(JiveGlobals.getHomePath().resolve("conf").toString())
         .setDynamic(false)
         .setPlugin(HazelcastPlugin.PLUGIN_NAME)
         .build();


### PR DESCRIPTION
This commit replaces usage of API that is removed in Openfire 4.9.0.

The replacement API was already available in Openfire 4.8.1, which remains the minimum version required by this plugin.