### PR TITLE
Prevent race condition when cluster is being initialized

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ Hazelcast Clustering Plugin Changelog
 
 <p><b>3.0.1</b> -- (To be determined)</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/103'>Issue #103</a>] - Fix Cluster initialization race condition</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/102'>Issue #102</a>] - Remove unused code in ClusterListener</li>
 </ul>
 

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterListener.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterListener.java
@@ -33,12 +33,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.*;
 
 /**
  * ClusterListener reacts to membership changes in the cluster. It takes care of cleaning up the state
@@ -50,7 +51,7 @@ public class ClusterListener implements MembershipListener, LifecycleListener {
 
     private boolean seniorClusterMember = false;
 
-    private final Cluster cluster;
+    private final CompletableFuture<Cluster> clusterFuture = new CompletableFuture<>();
     private final Map<NodeID, ClusterNodeInfo> clusterNodesInfo = new ConcurrentHashMap<>();
     
     /**
@@ -65,12 +66,26 @@ public class ClusterListener implements MembershipListener, LifecycleListener {
     private boolean clusterMember = false;
     private boolean isSenior;
 
-    ClusterListener(final Cluster cluster) {
+    synchronized void register(final Cluster cluster) {
+        this.clusterFuture.complete(cluster);
 
-        this.cluster = cluster;
         for (final Member member : cluster.getMembers()) {
             clusterNodesInfo.put(ClusteredCacheFactory.getNodeID(member),
                     new HazelcastClusterNodeInfo(member, cluster.getClusterTime()));
+        }
+    }
+
+    synchronized void unregister() {
+        if (!this.clusterFuture.isDone()) {
+            this.clusterFuture.cancel(true);
+        }
+    }
+
+    private Cluster getCluster() {
+        try {
+            return clusterFuture.get(Duration.ofMinutes(5).toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new RuntimeException("Cluster initialization failed", e);
         }
     }
 
@@ -81,6 +96,10 @@ public class ClusterListener implements MembershipListener, LifecycleListener {
 
     synchronized void joinCluster() {
         if (!isDone()) { // already joined
+            return;
+        }
+
+        if (!clusterFuture.isDone()) { // cluster still initializing.
             return;
         }
 
@@ -101,14 +120,14 @@ public class ClusterListener implements MembershipListener, LifecycleListener {
         CacheFactory.doClusterTask(new NewClusterMemberJoinedTask());
 
         logger.info("Joined cluster. XMPPServer node={}, Hazelcast UUID={}, seniorClusterMember={}",
-            new Object[]{ClusteredCacheFactory.getNodeID(cluster.getLocalMember()), cluster.getLocalMember().getUuid(), seniorClusterMember});
+            ClusteredCacheFactory.getNodeID(getCluster().getLocalMember()), getCluster().getLocalMember().getUuid(), seniorClusterMember);
         done = false;
     }
 
     boolean isSeniorClusterMember() {
         // first cluster member is the oldest
-        final Iterator<Member> members = cluster.getMembers().iterator();
-        return members.next().getUuid().equals(cluster.getLocalMember().getUuid());
+        final Iterator<Member> members = getCluster().getMembers().iterator();
+        return members.next().getUuid().equals(getCluster().getLocalMember().getUuid());
     }
 
     private synchronized void leaveCluster() {
@@ -129,7 +148,7 @@ public class ClusterListener implements MembershipListener, LifecycleListener {
             XMPPServer.getInstance().getPresenceUpdateHandler().removedExpiredPresences();
         }
         logger.info("Left cluster. XMPPServer node={}, Hazelcast UUID={}, wasSeniorClusterMember={}",
-            new Object[]{ClusteredCacheFactory.getNodeID(cluster.getLocalMember()), cluster.getLocalMember().getUuid(), wasSeniorClusterMember});
+            ClusteredCacheFactory.getNodeID(getCluster().getLocalMember()), getCluster().getLocalMember().getUuid(), wasSeniorClusterMember);
         done = true;
     }
 
@@ -137,39 +156,46 @@ public class ClusterListener implements MembershipListener, LifecycleListener {
     public void memberAdded(final MembershipEvent event) {
         logger.info("Received a Hazelcast memberAdded event {}", event);
 
-        final boolean wasSenior = isSenior;
-        isSenior = isSeniorClusterMember();
-        // local member only
         final NodeID nodeID = ClusteredCacheFactory.getNodeID(event.getMember());
-        if (event.getMember().localMember()) { // We left and re-joined the cluster
-            joinCluster();
+        if (clusterFuture.isDone())
+        {
+            final boolean wasSenior = isSenior;
+            isSenior = isSeniorClusterMember();
+            // local member only
+            if (event.getMember().localMember()) { // We left and re-joined the cluster
+                joinCluster();
 
-        } else {
-            if (wasSenior && !isSenior) {
-                logger.warn("Recovering from split-brain; firing leftCluster()/joinedCluster() events");
-                ClusteredCacheFactory.fireLeftClusterAndWaitToComplete(Duration.ofSeconds(30));
-                logger.debug("Firing joinedCluster() event");
-                ClusterManager.fireJoinedCluster(false);
+            } else {
+                if (wasSenior && !isSenior) {
+                    logger.warn("Recovering from split-brain; firing leftCluster()/joinedCluster() events");
+                    ClusteredCacheFactory.fireLeftClusterAndWaitToComplete(Duration.ofSeconds(30));
+                    logger.debug("Firing joinedCluster() event");
+                    ClusterManager.fireJoinedCluster(false);
 
-                try {
-                    logger.debug("Postponing notification of other nodes for 30 seconds. This allows all local leave/join processing to be finished and local cache backups to be stabilized before receiving events from other nodes.");
-                    Thread.sleep(30000L);
-                } catch (InterruptedException e) {
-                    logger.warn("30 Second wait was interrupted.", e);
+                    try {
+                        logger.debug("Postponing notification of other nodes for 30 seconds. This allows all local leave/join processing to be finished and local cache backups to be stabilized before receiving events from other nodes.");
+                        Thread.sleep(30000L);
+                    } catch (InterruptedException e) {
+                        logger.warn("30 Second wait was interrupted.", e);
+                    }
+
+                    // The following line was intended to wait until all local handling finishes before informing other
+                    // nodes. However that proved to be insufficient. Hence the 30 second default wait in the lines above.
+                    // TODO Instead of the 30 second wait, we should look (and then wait) for some trigger or event that signifies that local handling has completed and caches have stabilized.
+                    waitForClusterCacheToBeInstalled();
+
+                    // Let the other nodes know that we joined the cluster
+                    logger.debug("Done joining the cluster in split brain recovery. Now proceed informing other nodes that we joined the cluster.");
+                    CacheFactory.doClusterTask(new NewClusterMemberJoinedTask());
                 }
-
-                // The following line was intended to wait until all local handling finishes before informing other
-                // nodes. However that proved to be insufficient. Hence the 30 second default wait in the lines above.
-                // TODO Instead of the 30 second wait, we should look (and then wait) for some trigger or event that signifies that local handling has completed and caches have stabilized.
-                waitForClusterCacheToBeInstalled();
-
-                // Let the other nodes know that we joined the cluster
-                logger.debug("Done joining the cluster in split brain recovery. Now proceed informing other nodes that we joined the cluster.");
-                CacheFactory.doClusterTask(new NewClusterMemberJoinedTask());
             }
+            clusterNodesInfo.put(nodeID,
+                new HazelcastClusterNodeInfo(event.getMember(), getCluster().getClusterTime()));
+        } else {
+            logger.info("Skip memberAdded event {} processing while cluster is being initialized.", event);
+            clusterNodesInfo.put(nodeID,
+                new HazelcastClusterNodeInfo(event.getMember(), Instant.now().toEpochMilli()));
         }
-        clusterNodesInfo.put(nodeID,
-                new HazelcastClusterNodeInfo(event.getMember(), cluster.getClusterTime()));
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterListener.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterListener.java
@@ -34,8 +34,12 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.LocalTime;
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * ClusterListener reacts to membership changes in the cluster. It takes care of cleaning up the state
@@ -64,7 +68,7 @@ public class ClusterListener implements MembershipListener, LifecycleListener {
     private boolean isSenior;
 
     synchronized void register(final Cluster cluster) {
-        logger.info("Cluster is being established. Executing queued events (if any).");
+        logger.info("Registering with cluster. Executing any queued events to complete Openfire cluster formation.");
         this.cluster = cluster;
         this.clusterFuture.complete(cluster);
 
@@ -75,7 +79,7 @@ public class ClusterListener implements MembershipListener, LifecycleListener {
     }
 
     synchronized void unregister() {
-        logger.info("Unregistering cluster. Cancelling queued events (if any)");
+        logger.info("Unregistering with cluster. Cancelling any events to that where queued for completing Openfire cluster formation.");
         if (!this.clusterFuture.isDone()) {
             this.clusterFuture.cancel(true);
         }


### PR DESCRIPTION
The existing implementation suffers from a race condition that is described in #103.

This PR provides fixes in the first two commits:
- the first commit fixes the race condition in a clunky way
- the second commit improves the fix

Each commit has a commit message that describes the changes made in that commit.

Upon merge, these commits should possibly be squashed. I left them unsquashed for your reviewing pleasure.

Initial tests are promising, but more testing is needed. I'm creating this PR mainly because I've got a nagging feeling that there's room for improvement, that I can't quite put my finger on. I'm hoping for reviewing feedback. :)