### PR TITLE
fixes #105: Reported cache max size

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ Hazelcast Clustering Plugin Changelog
 
 <p><b>3.0.1</b> -- (To be determined)</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/105'>Issue #105</a>] - Maximum cache size (in bytes) incorrectly reported</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/103'>Issue #103</a>] - Fix Cluster initialization race condition</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/102'>Issue #102</a>] - Remove unused code in ClusterListener</li>
 </ul>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>${project.description}</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2024-11-02</date>
+    <date>2024-11-05</date>
     <minServerVersion>4.8.1</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
 </plugin>

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCache.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCache.java
@@ -302,6 +302,15 @@ public class ClusteredCache<K extends Serializable, V extends Serializable> impl
 
     @Override
     public long getMaxCacheSize() {
+        final int size = config.getEvictionConfig().getSize();
+        if (size == Integer.MAX_VALUE) {
+            return -1; // Hazelcast doesn't use negative values.
+        }
+
+        if (getCapacityUnit() != null && getCapacityUnit() == CapacityUnit.BYTES) {
+            return config.getEvictionConfig().getSize() * 1024 * 1024L; // Hazelcast stores this as megabyte, not byte.
+        }
+
         return config.getEvictionConfig().getSize();
     }
 


### PR DESCRIPTION
The maximum cache size was reported by the ClusteredCache implementation incorrectly, when based on Openfire-provided configuration.

This change effectively reverts the value modifications performed by `org.jivesoftware.openfire.plugin.util.cache.ClusteredCacheFactory#createCache`