### PR TITLE
Support locks in SerializingCache

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ Hazelcast Clustering Plugin Changelog
 <p><b>5.5.0 Release 2</b> -- tbd</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/117'>Issue #117</a>] - Fix cluster node page cannot open</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/112'>Issue #112</a>] - Support locks in SerializingCache</li>
 </ul>
 
 <p><b>5.5.0 Release 1</b> -- June 12, 2025</p>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>5.0.0-beta</version>
+        <version>5.0.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>hazelcast</artifactId>

--- a/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
@@ -40,6 +40,7 @@ import org.jivesoftware.util.cache.CacheWrapper;
 import org.jivesoftware.util.cache.ClusterTask;
 import org.jivesoftware.util.cache.ExternalizableUtil;
 import org.jivesoftware.util.cache.ExternalizableUtilStrategy;
+import org.jivesoftware.util.cache.SerializingCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -288,6 +289,9 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
     public void destroyCache(Cache cache) {
         if (cache instanceof CacheWrapper) {
             cache = ((CacheWrapper) cache).getWrappedCache();
+        }
+        if (cache instanceof SerializingCache) {
+            cache = ((SerializingCache) cache).getDelegate();
         }
 
         final ClusteredCache clustered = (ClusteredCache) cache;


### PR DESCRIPTION
The plugin now requires Openfire 5.0.0 or later.

fixes #112

I'm marking this PR as 'draft', as the Openfire dependency needs to be `5.0.0` instead of `5.0.0-SNAPSHOT`. At the time of writing, the `5.0.0` release isn't available yet.