### PR TITLE
Compatibility with Openfire 5.0.0 / OF-3088

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -45,9 +45,11 @@ Hazelcast Clustering Plugin Changelog
 </h1>
 
 <p><b>5.5.0 Release 1</b> -- (To be determined)</p>
+<strong>NOTE: This version of the plugin requires Openfire 5.0.0 or higher</strong>
 <ul>
     <li>Minimum Java requirement: 17</li>
     <li>Adopted a new versioning scheme: the version number now reflects the version of the Hazelcast library that is in use.</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/114'>Issue #114</a>] - Compatible with Openfire 5.0.0</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/109'>Issue #109</a>] - Improve task execution logging</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/101'>Issue #101</a>] - Upgrade to Hazelcast 5.5.0</li>
 </ul>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>${project.description}</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2025-01-06</date>
-    <minServerVersion>4.8.1</minServerVersion>
+    <date>2025-06-11</date>
+    <minServerVersion>5.0.0</minServerVersion>
     <minJavaVersion>17</minJavaVersion>
 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.8.1</version>
+        <version>5.0.0-beta</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>hazelcast</artifactId>


### PR DESCRIPTION
Under OF-3088, the clustered lock implementation is modified in Openfire 5.0.0.

The changes in this commit apply similar changes to the Hazelcast plugin.

This change makes the plugin incompatible with versions of Openfire prior to version 5.0.0.

fixes #144

I'm marking this PR as 'draft', as the Openfire dependency needs to be 5.0.0 instead of 5.0.0-SNAPSHOT. At the time of writing, the 5.0.0 release isn't available yet.

This change possibly takes away the need for #113 