### PR TITLE
fix #128: Fix 'senior member' state in ClusterNodeInfo

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -45,6 +45,7 @@ Hazelcast Clustering Plugin Changelog
 </h1>
 <p><b>5.5.0 Release 2</b> -- tbd</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/128'>Issue #128</a>] - Fix incorrect Senior Member state in HazelcastClusterNodeInfo</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/117'>Issue #117</a>] - Fix cluster node page cannot open</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/112'>Issue #112</a>] - Support locks in SerializingCache</li>
 </ul>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>${project.description}</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2025-06-12</date>
+    <date>2026-03-18</date>
     <minServerVersion>5.0.0</minServerVersion>
     <minJavaVersion>17</minJavaVersion>
 </plugin>

--- a/src/java/org/jivesoftware/openfire/plugin/util/cluster/HazelcastClusterNodeInfo.java
+++ b/src/java/org/jivesoftware/openfire/plugin/util/cluster/HazelcastClusterNodeInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2009 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2009 Jive Software, 2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,13 +36,11 @@ public class HazelcastClusterNodeInfo implements ClusterNodeInfo {
     private final String hostname;
     private final NodeID nodeID;
     private final long joinedTime;
-    private final boolean seniorMember;
 
     public HazelcastClusterNodeInfo(final Member member, final long joinedTime) {
         this.hostname = member.getAttribute(HOST_NAME_ATTRIBUTE) + " (" + member.getSocketAddress().getHostString() + ")";
         this.nodeID = ClusteredCacheFactory.getNodeID(member);
         this.joinedTime = joinedTime;
-        this.seniorMember = ClusterManager.getSeniorClusterMember().equals(nodeID);
     }
 
     public String getHostName() {
@@ -58,6 +56,6 @@ public class HazelcastClusterNodeInfo implements ClusterNodeInfo {
     }
 
     public boolean isSeniorMember() {
-        return seniorMember;
+        return ClusterManager.getSeniorClusterMember().equals(nodeID);
     }
 }


### PR DESCRIPTION
Replace the immutable `seniorMember` field with a dynamic lookup that determines node seniority at the time the getter is invoked.

Previously, the value was set during initialization, when a node had not yet joined the cluster and was incorrectly considered the senior member. As cluster membership and leadership can change over time, this resulted in stale and incorrect data being exposed.

The getter now queries the current cluster state to ensure accurate and up-to-date seniority information.